### PR TITLE
Add a Result wrapper class

### DIFF
--- a/local_persistence_form_sample/lib/Core/result.dart
+++ b/local_persistence_form_sample/lib/Core/result.dart
@@ -1,0 +1,16 @@
+typedef AsyncResultFunction<T> =
+    Future<Result<T?, Error>> Function(dynamic input);
+
+sealed class Result<T, E extends Error> {}
+
+final class Success<T, E extends Error> extends Result<T, E> {
+  final T value;
+  Success(this.value);
+}
+
+final class Failure<T, E extends Error> extends Result<T, E> {
+  final E error;
+  final String? message;
+  Failure(this.error, [this.message]);
+}
+


### PR DESCRIPTION
Handles errors and success to avoid throwing in the app an instead handle case by case without try catch in the widgets.